### PR TITLE
Fix digitalread not always sending a message from setup

### DIFF
--- a/Telemetrix4RpiPico.c
+++ b/Telemetrix4RpiPico.c
@@ -247,6 +247,7 @@ void set_pin_mode()
     case DIGITAL_INPUT_PULL_DOWN:
         the_digital_pins[pin].pin_mode = mode;
         the_digital_pins[pin].reporting_enabled = command_buffer[SET_PIN_MODE_DIGITAL_IN_REPORTING_STATE];
+        the_digital_pins[pin].last_value = 0xFF;
         gpio_init(pin);
         gpio_set_dir(pin, GPIO_IN);
         if (mode == DIGITAL_INPUT_PULL_UP)


### PR DESCRIPTION
Fixes https://github.com/mirte-robot/mirte-ros-packages/issues/25 by setting last_value to something that digitalread cannot be, such that it will always send a message as it checks for changes before sending