### PR TITLE
Servos always send once a second msg

### DIFF
--- a/include/module/Hiwonder_Servo.hpp
+++ b/include/module/Hiwonder_Servo.hpp
@@ -50,4 +50,5 @@ private:
   HiwonderBus *bus = nullptr;
   std::vector<HiwonderServo *> servos = {};
   int enabled_servos = 0;
+  decltype(time_us_32()) last_force_write = 0;
 };

--- a/src/module/Hiwonder_Servo.cpp
+++ b/src/module/Hiwonder_Servo.cpp
@@ -233,10 +233,12 @@ void Hiwonder_Servo::readModule() {
     }
     auto diff = std::abs(pos - servo->lastPublishedPosition);
     const auto min_diff = 24 * 3; // 3 ticks, or 72 centidegrees
-    if (diff > min_diff) {
+    if (diff > min_diff || time_us_32() - this->last_force_write >
+                               1'000'000) { // force write every second
       data.push_back(i);
       // Pos is 0...24000 -> 15 bits
       append_range(data, encode_u16(pos));
+      this->last_force_write = time_us_32();
     }
     servo->lastPublishedPosition = pos;
     i++;


### PR DESCRIPTION
Tmx on orange pi side is sometimes a bit slow and doesn't register the first position update. Without any periodic forced updates, the servo positions seem to be stuck at 0 until they are moved (by external or internal motor).

This fix forces an update at 1Hz for each servo, resulting in always correct known positions on computer side and immediate (<1s) working ros-control.