### PR TITLE
Add pico2 support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,15 +29,9 @@ jobs:
             run: |
               cp ./build2/Telemetrix4RpiPico.uf2 ./
               cp ./build2/Telemetrix4RpiPico.elf ./
-          # - name: install nodejs
-          #   run: |
-          #       apt update
-          #       apt install curl unzip -y
-          #       curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh
-          #       chmod +x nodesource_setup.sh
-          #       ./nodesource_setup.sh
-          #       apt-get install -y nodejs
-          #       node -v
+              cp ./build_pico2/Telemetrix4RpiPico_merged.uf2 ./Telemetrix4RpiPico_merged.uf2
+              cp ./build_pico2/Telemetrix4RpiPico.elf ./Telemetrix4RpiPico_pico2.elf
+              cp ./build_pico2/Telemetrix4RpiPico.uf2 ./Telemetrix4RpiPico_pico2.uf2
           - name: Put environment variable into the env context
             run: echo "app_name=$APP_NAME" >> $GITHUB_ENV
           - name: Archive production artifacts
@@ -47,6 +41,9 @@ jobs:
               path: |
                 Telemetrix4RpiPico.uf2
                 Telemetrix4RpiPico.elf
+                Telemetrix4RpiPico_merged.uf2
+                Telemetrix4RpiPico_pico2.elf
+                Telemetrix4RpiPico_pico2.uf2
           - name: Push to release
             uses: softprops/action-gh-release@v3
             if: startsWith(github.ref, 'refs/tags/')
@@ -54,6 +51,9 @@ jobs:
                 files: |
                   Telemetrix4RpiPico.uf2
                   Telemetrix4RpiPico.elf
+                  Telemetrix4RpiPico_merged.uf2
+                  Telemetrix4RpiPico_pico2.elf
+                  Telemetrix4RpiPico_pico2.uf2
                 generate_release_notes: true
           - name: Check if mirte-sd-image-tools has release with same tag
             id: check_release
@@ -87,6 +87,9 @@ jobs:
               files: |
                 Telemetrix4RpiPico.uf2
                 Telemetrix4RpiPico.elf
+                # Telemetrix4RpiPico_merged.uf2
+                # Telemetrix4RpiPico_pico2.elf
+                # Telemetrix4RpiPico_pico2.uf2
               generate_release_notes: false
               tag_name: ${{ github.ref_name }}
               token: ${{ secrets.RELEASE_TOKEN }} # needs contents permission on mirte-sd-image-tools 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 test/
 build2/
 build_rel/
+build_pico2/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,12 +109,15 @@ target_link_libraries(
   pico_ssd1306
   Adafruit_BNO055)
 
-set(SKIP_BOOTLOADER_ENTRY_PIN 1)
-add_subdirectory(rp2040-serial-bootloader)
-# pico_set_linker_script(Telemetrix4RpiPico
-# ${CMAKE_CURRENT_SOURCE_DIR}/blink_noboot2.ld)
-
-bootloader_build_combined(Telemetrix4RpiPico)
+# if PICO_BOARD starts with "pico" and not "pico2", then we can add the serial
+# bootloader
+if(PICO_BOARD MATCHES "^pico" AND NOT PICO_BOARD MATCHES "^pico2")
+  # this bootloader only works for pico and pico_w, not for pico2, so we only
+  # add it for those boards
+  set(SKIP_BOOTLOADER_ENTRY_PIN 1)
+  add_subdirectory(rp2040-serial-bootloader)
+  bootloader_build_combined(Telemetrix4RpiPico)
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_custom_target(

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # de8ae5a
-set -e
+set -ex
 git config --global --add safe.directory /__w/Telemetrix4RpiPico/Telemetrix4RpiPico # fix for cmake not reading git stuff
-mkdir build2/
+mkdir -p build2/
 ls
 cd build2
 # Sometimes the debug build reports more errors than Release
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -DPICO_BOARD=pico ..
 make -j
 cd ..
 # rm -rf build2
@@ -17,3 +17,10 @@ cd ..
 # make
 sha256sum * || true
 sha256sum build/* || true
+
+mkdir -p build_pico2/
+cd build_pico2/
+cmake -DCMAKE_BUILD_TYPE=Release -DPICO_BOARD=pico2 ..
+make -j3
+cd ..
+cat build2/Telemetrix4RpiPico.uf2 build_pico2/Telemetrix4RpiPico.uf2 > build_pico2/Telemetrix4RpiPico_merged.uf2


### PR DESCRIPTION
Disables uart bootloader when pico2 as the linker scripts are not for those.

Merged uf2 can be moved to any pico(1, RP2040) and pico2(RP2350) board when in bootloader mode.

After https://github.com/raspberrypi/picotool/pull/349 is merged and released we can use the merged by default, otherwise the upload scripts will crash when uploading the merged file.

The Telemetrix4RpiPico_pico2.{elf,uf2} files can be used for pico2 boards.
The non _pico2 files are for the RP2040 pico only.